### PR TITLE
Feature/fix shutdown deadlock

### DIFF
--- a/slipstream/core.py
+++ b/slipstream/core.py
@@ -91,6 +91,9 @@ class Conf(metaclass=Singleton):
             ])
         except KeyboardInterrupt:
             pass
+        except Exception as e:
+            logger.critical(e)
+            raise
         finally:
             await self._shutdown()
 
@@ -309,7 +312,10 @@ class Topic:
             try:
                 await wait_for(client.stop(), timeout=10)
             except TimeoutError:
-                pass
+                logger.critical(
+                    f'Client for topic "{self.name}" failed '
+                    f'to shut down gracefully: {client}'
+                )
 
 
 async def _sink_output(


### PR DESCRIPTION
In rare cases a deadlock occurred when the client was trying to rejoin a group while an error was raised in the application itself. The shutdown process froze, and manual intervention was required to restart the application. A timeout on the shutdown process prevents this from happening, but may cause ungraceful shutdowns.

Similar issues:
- https://github.com/aio-libs/aiokafka/issues/773