### PR TITLE
Add basic pipe functionality.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.398
+    rev: v1.1.399
     hooks:
       - id: pyright
   - repo: https://github.com/pycqa/pydocstyle

--- a/README.md
+++ b/README.md
@@ -41,18 +41,20 @@ Hello 👌!
 
 ## Usage
 
-Async `iterables` are sources, (async) `callables` are sinks.
+Slipstream components interoperate with basic python building blocks:
 
-Decorate handler functions using `handle`, then run `stream` to start processing:
+- `Any`-thing can be passed around as data
+- Any `Callable` may be used as a sink
+- `AsyncIterables` act as sources
+- Parallelize through `handle`
 
 <img src="https://raw.githubusercontent.com/menziess/slipstream/master/docs/source/_static/demo.gif" />
 
-Multiple sources and sinks can be provided to establish many-to-many relations between them.
-The 4 emoji's were printed using the callable `print`.
+By passing more than one source/sink, a many-to-many relation can be achieved between them.
 
 ## Quickstart
 
-Install `aiokafka` (latest) along with slipstream:
+Install Slipstream along with `aiokafka` (latest):
 
 ```sh
 pip install slipstream-async[kafka]
@@ -64,14 +66,14 @@ Spin up a local Kafka broker with [docker-compose.yml](docker-compose.yml), usin
 docker compose up broker -d
 ```
 
-Follow the docs and set up a Kafka connection: [slipstream.readthedocs.io](https://slipstream.readthedocs.io/en/latest/getting_started.html#kafka).
+Copy-paste this snippet: [slipstream.readthedocs.io](https://slipstream.readthedocs.io/en/latest/getting_started.html#kafka).
 
 ## Features
 
-- [`slipstream.handle`](slipstream/__init__.py): bind streams (iterables) and sinks (callables) to user defined handler functions
-- [`slipstream.stream`](slipstream/__init__.py): start streaming
-- [`slipstream.Topic`](slipstream/core.py): consume from (iterable), and produce to (callable) kafka using [**aiokafka**](https://aiokafka.readthedocs.io/en/stable/index.html)
-- [`slipstream.Cache`](slipstream/caching.py): store data to disk using [**rocksdict**](https://rocksdict.github.io/RocksDict/rocksdict.html)
-- [`slipstream.Conf`](slipstream/core.py): set global kafka configuration (can be overridden per topic)
-- [`slipstream.codecs.JsonCodec`](slipstream/codecs.py): serialize and deserialize json messages
-- [`slipstream.checkpointing.Checkpoint`](slipstream/checkpointing.py): recover from stream downtimes
+- [`slipstream.handle`](https://slipstream.readthedocs.io/en/latest/slipstream.html#slipstream.handle): bind streams (iterables) and sinks (callables) to user defined handler functions
+- [`slipstream.stream`](https://slipstream.readthedocs.io/en/latest/slipstream.html#slipstream.stream): start streaming
+- [`slipstream.Topic`](https://slipstream.readthedocs.io/en/latest/slipstream.html#slipstream.core.Topic): consume from (iterable), and produce to (callable) kafka using [**aiokafka**](https://aiokafka.readthedocs.io/en/stable/index.html)
+- [`slipstream.Cache`](https://slipstream.readthedocs.io/en/latest/slipstream.html#slipstream.Cache): store data to disk using [**rocksdict**](https://rocksdict.github.io/RocksDict/rocksdict.html)
+- [`slipstream.Conf`](https://slipstream.readthedocs.io/en/latest/slipstream.html#slipstream.Conf): set global kafka configuration (can be overridden per topic)
+- [`slipstream.codecs.JsonCodec`](https://slipstream.readthedocs.io/en/latest/autoapi/slipstream/codecs/index.html#slipstream.codecs.JsonCodec): serialize and deserialize json messages
+- [`slipstream.checkpointing.Checkpoint`](https://slipstream.readthedocs.io/en/latest/autoapi/slipstream/checkpointing/index.html#slipstream.checkpointing.Checkpoint): recover from stream downtimes

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Slipstream components interoperate with basic python building blocks:
 
 <img src="https://raw.githubusercontent.com/menziess/slipstream/master/docs/source/_static/demo.gif" />
 
-By passing more than one source/sink, a many-to-many relation can be achieved between them.
+A many-to-many relation is established by passing multiple sources / sinks.
 
 ## Quickstart
 
@@ -66,7 +66,7 @@ Spin up a local Kafka broker with [docker-compose.yml](docker-compose.yml), usin
 docker compose up broker -d
 ```
 
-Copy-paste this snippet: [slipstream.readthedocs.io](https://slipstream.readthedocs.io/en/latest/getting_started.html#kafka).
+Copy-paste [this snippet](https://slipstream.readthedocs.io/en/latest/getting_started.html#kafka).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ Spin up a local Kafka broker with [docker-compose.yml](docker-compose.yml), usin
 docker compose up broker -d
 ```
 
-Copy-paste [this snippet](https://slipstream.readthedocs.io/en/latest/getting_started.html#kafka).
+Copy-paste [this snippet](https://slipstream.readthedocs.io/en/stable/getting_started.html#kafka).
 
 ## Features
 
-- [`slipstream.handle`](https://slipstream.readthedocs.io/en/latest/slipstream.html#slipstream.handle): bind streams (iterables) and sinks (callables) to user defined handler functions
-- [`slipstream.stream`](https://slipstream.readthedocs.io/en/latest/slipstream.html#slipstream.stream): start streaming
-- [`slipstream.Topic`](https://slipstream.readthedocs.io/en/latest/slipstream.html#slipstream.core.Topic): consume from (iterable), and produce to (callable) kafka using [**aiokafka**](https://aiokafka.readthedocs.io/en/stable/index.html)
-- [`slipstream.Cache`](https://slipstream.readthedocs.io/en/latest/slipstream.html#slipstream.Cache): store data to disk using [**rocksdict**](https://rocksdict.github.io/RocksDict/rocksdict.html)
-- [`slipstream.Conf`](https://slipstream.readthedocs.io/en/latest/slipstream.html#slipstream.Conf): set global kafka configuration (can be overridden per topic)
-- [`slipstream.codecs.JsonCodec`](https://slipstream.readthedocs.io/en/latest/autoapi/slipstream/codecs/index.html#slipstream.codecs.JsonCodec): serialize and deserialize json messages
-- [`slipstream.checkpointing.Checkpoint`](https://slipstream.readthedocs.io/en/latest/autoapi/slipstream/checkpointing/index.html#slipstream.checkpointing.Checkpoint): recover from stream downtimes
+- [`slipstream.handle`](https://slipstream.readthedocs.io/en/stable/slipstream.html#slipstream.handle): bind streams (iterables) and sinks (callables) to user defined handler functions
+- [`slipstream.stream`](https://slipstream.readthedocs.io/en/stable/slipstream.html#slipstream.stream): start streaming
+- [`slipstream.Topic`](https://slipstream.readthedocs.io/en/stable/slipstream.html#slipstream.core.Topic): consume from (iterable), and produce to (callable) kafka using [**aiokafka**](https://aiokafka.readthedocs.io/en/stable/index.html)
+- [`slipstream.Cache`](https://slipstream.readthedocs.io/en/stable/slipstream.html#slipstream.Cache): store data to disk using [**rocksdict**](https://rocksdict.github.io/RocksDict/rocksdict.html)
+- [`slipstream.Conf`](https://slipstream.readthedocs.io/en/stable/slipstream.html#slipstream.Conf): set global kafka configuration (can be overridden per topic)
+- [`slipstream.codecs.JsonCodec`](https://slipstream.readthedocs.io/en/stable/autoapi/slipstream/codecs/index.html#slipstream.codecs.JsonCodec): serialize and deserialize json messages
+- [`slipstream.checkpointing.Checkpoint`](https://slipstream.readthedocs.io/en/stable/autoapi/slipstream/checkpointing/index.html#slipstream.checkpointing.Checkpoint): recover from stream downtimes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,24 @@
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.4.0
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
   broker:
-    image: confluentinc/cp-kafka:7.4.0
+    image: confluentinc/cp-kafka:7.9.0
     hostname: broker
     container_name: broker
-    depends_on:
-      - zookeeper
     ports:
       - "29091:29091"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9091,PLAINTEXT_HOST://localhost:29091
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://broker:9091,PLAINTEXT_HOST://localhost:29091"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: "broker,controller"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@broker:29093"
+      KAFKA_LISTENERS: "PLAINTEXT://broker:9091,PLAINTEXT_HOST://0.0.0.0:29091,CONTROLLER://broker:29093"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "PLAINTEXT"
+      KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      CLUSTER_ID: "zRLwK6QtSHyZeUgyeKKV7A"
     healthcheck:
       test:
         [

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,16 +11,16 @@ Slipstream provides a data-flow model to simplify development of stateful stream
 - **Freedom:** allowing arbitrary code free of limiting abstractions
 - **Speed:** optimized and configurable defaults to get started quickly
 
-Consume data from any ``Async Iterable`` source: Kafka, Streaming API's, Python generators, Cache updates.
-Produce data to any ``Callable``: Kafka, RocksDB, API's, Databases.
-Perform any arbitrary stateful operation using regular Python code: Joining, Aggregating, Filtering.
-Detect and handle dependency stream downtimes: Pausing, Catching up, Resuming, and Correcting.
+Consume any ``AsyncIterable`` source: *Kafka, Streaming API's, Python generators, Cache updates*.
+Produce to any ``Callable``: *Kafka, RocksDB, API's, Databases*.
+Perform any arbitrary stateful operation using regular Python code: *filters, joins, aggregations, pairwise* or *batching*.
+Detect and handle dependency stream downtimes: *pausing, catching up, resuming*, and *making corrections*.
 
 Demo
 ^^^^
 
-Because everything is built with basic python building blocks, framework-like features can be crafted with ease.
-For instance, while timers aren't included, you can whip one up effortlessly:
+Slipstream components interoperate with basic python building blocks, making it easy to craft framework-like features.
+For instance, while timers aren't included, you can whip one up effortlessly (``AsyncIterable``):
 
 ::
 
@@ -31,13 +31,13 @@ For instance, while timers aren't included, you can whip one up effortlessly:
             await sleep(interval)
             yield
 
-We'll use ``print`` as our sink:
+We'll use ``print`` as our sink (``Callable``):
 
 .. code-block:: python
 
     print
 
-Let's send our mascot 🐟 *-- blub* downstream on a regular 1 second interval:
+Let's send our mascot "🐟 *-- blub*" downstream:
 
 ::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ line-length = 79
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-addopts = "--doctest-modules"
+addopts = "--doctest-modules --cov=slipstream --cov-report=term-missing"
 doctest_optionflags = "ELLIPSIS"
 testpaths = [
   "slipstream",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Streamline your stream processing."
 authors = [{ name = "Menziess", email = "stefan_schenk@hotmail.com" }]
 readme = "README.md"
 license = { text = "MIT" }
-keywords = ["kafka", "pubsub"]
+keywords = ["python", "streaming", "kafka", "stream-processing", "data-engineering", "dataflow", "data-processing", "streaming-data", "slipstream", "stateful-streaming"]
 classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",

--- a/slipstream/core.py
+++ b/slipstream/core.py
@@ -3,7 +3,6 @@
 import logging
 from asyncio import gather, sleep, wait_for
 from collections.abc import AsyncIterable
-from enum import Enum
 from inspect import isasyncgenfunction, signature
 from re import sub
 from typing import (
@@ -23,6 +22,7 @@ from slipstream.interfaces import ICache, ICodec
 from slipstream.utils import (
     AsyncCallable,
     PubSub,
+    Signal,
     Singleton,
     get_param_names,
     iscoroutinecallable,
@@ -39,7 +39,6 @@ except ImportError:
 __all__ = [
     'READ_FROM_START',
     'READ_FROM_END',
-    'Signal',
     'PausableStream',
     'Topic',
 ]
@@ -50,19 +49,6 @@ READ_FROM_END = -1
 
 
 _logger = logging.getLogger(__name__)
-
-
-class Signal(Enum):
-    """Signals can be exchanged with streams.
-
-    SENTINEL represents an absent yield value
-    PAUSE    represents the signal to pause stream
-    RESUME   represents the signal to resume stream
-    """
-
-    SENTINEL = 0
-    PAUSE = 1
-    RESUME = 2
 
 
 class PausableStream:

--- a/slipstream/core.py
+++ b/slipstream/core.py
@@ -488,6 +488,9 @@ if aiokafka_available:
                         signal = yield msg
 
                         if signal is Signal.PAUSE:
+                            # Future calls to `getmany` will not return
+                            # any records from these partitions until
+                            # they have been resumed using `resume`
                             consumer.pause(*consumer.assignment())
                             _logger.debug(f'{self.name} paused')
                             while True:
@@ -497,9 +500,9 @@ if aiokafka_available:
                                     consumer.resume(*consumer.assignment())
                                     break
 
-                                # Send heartbeats through getmany
+                                # Send heartbeats through `getmany`
                                 await consumer.getmany()
-                                await sleep(1)
+                                await sleep(3)
 
                 except Exception as e:
                     _logger.error(

--- a/slipstream/core.py
+++ b/slipstream/core.py
@@ -342,7 +342,7 @@ if aiokafka_available:
         ):
             """Seek to offset."""
             c = consumer or self.consumer
-            if not c:
+            if c is None:
                 raise RuntimeError('No consumer provided.')
 
             if isinstance(offset, int) and offset < READ_FROM_START:

--- a/slipstream/utils.py
+++ b/slipstream/utils.py
@@ -1,6 +1,7 @@
 """Slipstream utilities."""
 
 from asyncio import Queue
+from enum import Enum
 from inspect import iscoroutinefunction, signature
 from typing import (
     Any,
@@ -11,6 +12,20 @@ from typing import (
 )
 
 AsyncCallable: TypeAlias = Callable[..., Awaitable[Any]] | Callable[..., Any]
+
+
+class Signal(Enum):
+    """Signals can be exchanged with streams.
+
+    SENTINEL represents an absent yield value
+    PAUSE    represents the signal to pause stream
+    RESUME   represents the signal to resume stream
+    """
+
+    SENTINEL = 0
+    PAUSE = 1
+    RESUME = 2
+    STOP = 3
 
 
 def iscoroutinecallable(o: Any) -> bool:

--- a/slipstream/utils.py
+++ b/slipstream/utils.py
@@ -178,6 +178,7 @@ class _GeneratorCopy:
                 await self._cond.wait()
             if self._root._value is Signal.STOP:
                 raise StopAsyncIteration
-            self._is_ready = True
-            self._cond.notify_all()
-            return self._root._value
+            else:
+                self._is_ready = True
+                self._cond.notify_all()
+                return self._root._value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,13 +37,11 @@ try:
 except ImportError:
     pass
 
-KAFKA_CONTAINER = 'confluentinc/cp-kafka:latest'
-
 
 @fixture(scope='session')
 def kafka():
     """Get running kafka broker."""
-    kafka = KafkaContainer(KAFKA_CONTAINER)
+    kafka = KafkaContainer().with_kraft()
     try:
         kafka.start()
         yield kafka.get_bootstrap_server()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,10 +57,11 @@ def timeout():
         def raise_timeout(*_):
             raise TimeoutError(f'Timeout reached: {seconds}.')
 
-        def start_timeout():
-            signal.signal(signal.SIGALRM, raise_timeout)
-            signal.alarm(seconds)
-        yield start_timeout()
+        signal.signal(signal.SIGALRM, raise_timeout)
+        signal.alarm(seconds)
+
+        yield
+
     return set_timeout
 
 


### PR DESCRIPTION
Attempting to add a feature that would allow transformations to the stream before it reaches the handler (using `asyncstdlib` in this case), ex;
```py
from asyncio import run, sleep

from asyncstdlib import pairwise

from slipstream import handle, stream

async def numbers(n=0):
    while True:
        await sleep(0.5)
        yield n
        n += 1

@handle(numbers(), pipe=[pairwise], sink=[print])
async def handler(pair):
    yield pair

run(stream())
```

```
(0, 1)
(1, 2)
(2, 3)
(3, 4)
(4, 5)
(5, 6)
(6, 7)
(7, 8)
(8, 9)
(9, 10)
```