### PR TITLE
Feature/improve checkpointing

### DIFF
--- a/docs/source/cookbook.rst
+++ b/docs/source/cookbook.rst
@@ -407,7 +407,7 @@ Some changes in our setup are required:
         'group_instance_id': 'activity',
         'group_id': 'activity',
     }, codec=JsonCodec(), offset=READ_FROM_END)
-    checkpoints_cache = Cache('state/checkpoints', target_table_size=1024)
+    checkpoints_cache = Cache('state/checkpoints', target_table_size=10000)
     weather_cache = Cache('state/weather')
 
 The ``Checkpoint`` defines the relationship between streams:

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -196,7 +196,7 @@ A checkpoint consists of one dependent, and many dependency streams:
     dependent, dependency = emoji(), emoji()
 
     # Cache for persisting one or more Checkpoints
-    checkpoints_cache = Cache('state/checkpoints', target_table_size=1024)
+    checkpoints_cache = Cache('state/checkpoints', target_table_size=10000)
 
     c = Checkpoint(
         'dependent', dependent=dependent,

--- a/slipstream/checkpointing.py
+++ b/slipstream/checkpointing.py
@@ -14,7 +14,6 @@ _logger = logging.getLogger(__name__)
 
 STATE_NAME = 'state'
 STATE_MARKER_NAME = 'state_marker'
-CHECKPOINT_IS_DOWN = 'checkpoint_is_down'
 CHECKPOINT_STATE_NAME = 'checkpoint_state'
 CHECKPOINT_MARKER_NAME = 'checkpoint_marker'
 CHECKPOINTS_NAME = 'checkpoints'
@@ -67,13 +66,6 @@ class Dependency:
         self._recovery_check = recovery_check or self._default_recovery_check
         self.is_down = False
 
-    def save_is_down(
-        self, cache: ICache, cache_key_prefix: str, is_down: bool
-    ) -> None:
-        """Save is_down checkpoint state to cache."""
-        key = f'{cache_key_prefix}{self.name}_'
-        cache[key + CHECKPOINT_IS_DOWN] = is_down
-
     def save(
         self,
         cache: ICache,
@@ -89,7 +81,6 @@ class Dependency:
     def load(self, cache: ICache, cache_key_prefix: str) -> None:
         """Load checkpoint state from cache."""
         key = f'{cache_key_prefix}{self.name}_'
-        self.is_down = cache[key + CHECKPOINT_IS_DOWN]
         self.checkpoint_state = cache[key + CHECKPOINT_STATE_NAME]
         self.checkpoint_marker = cache[key + CHECKPOINT_MARKER_NAME]
 
@@ -268,17 +259,6 @@ class Checkpoint:
             for dependency in self.dependencies.values():
                 dependency.load(self._cache, self._cache_key)
 
-        # Pause dependent if any dependency was down
-        # Callbacks will not be called at startup of the app
-        for dependency in self.dependencies.values():
-            if not dependency.is_down:
-                continue
-            log_msg = f'Downtime of dependency "{dependency.name}" detected'
-            _logger.debug(log_msg)
-            key, c = str(id(self.dependent)), Conf()
-            if self.pause_dependent and key in c.iterables:
-                c.iterables[key].send_signal(Signal.PAUSE)
-
     async def heartbeat(
         self,
         marker: datetime | Any,
@@ -309,7 +289,7 @@ class Checkpoint:
 
         if dependency.is_down:
             if await awaitable(dependency.recovery_check(self, dependency)):
-                self._save_dependency_is_down(dependency, False)
+                dependency.is_down = False
 
             if not any(_.is_down for _ in self.dependencies.values()):
                 _logger.debug(
@@ -379,7 +359,7 @@ class Checkpoint:
                         await self._downtime_callback(self, dependency)
                     else:
                         self._downtime_callback(self, dependency)
-                self._save_dependency_is_down(dependency, True)
+                dependency.is_down = True
 
         if any(_.is_down for _ in self.dependencies.values()):
             return downtime
@@ -413,15 +393,6 @@ class Checkpoint:
             checkpoint_state,
             checkpoint_marker,
         )
-
-    def _save_dependency_is_down(
-        self, dependency: Dependency, is_down: bool
-    ) -> None:
-        """Save is_down state of the dependency checkpoint (to cache)."""
-        dependency.is_down = is_down
-        if not self._cache:
-            return
-        dependency.save_is_down(self._cache, self._cache_key, is_down)
 
     def __getitem__(self, key: str) -> Dependency:
         """Get dependency from dependencies."""

--- a/slipstream/checkpointing.py
+++ b/slipstream/checkpointing.py
@@ -371,8 +371,10 @@ class Checkpoint:
         self.state_marker = state_marker
         if not self._cache:
             return
-        self._cache[f'{self._cache_key}_state'] = self.state
-        self._cache[f'{self._cache_key}_state_marker'] = self.state_marker
+        self._cache[f'{self._cache_key}_{STATE_NAME}'] = self.state
+        self._cache[f'{self._cache_key}_{STATE_MARKER_NAME}'] = (
+            self.state_marker
+        )
 
     def _save_checkpoint(
         self,

--- a/slipstream/core.py
+++ b/slipstream/core.py
@@ -516,9 +516,6 @@ if aiokafka_available:
                     signal = yield msg
 
                     if signal is Signal.PAUSE:
-                        # Future calls to `getmany` will not return
-                        # any records from these partitions until
-                        # they have been resumed using `resume`
                         consumer.pause(*consumer.assignment())
                         _logger.debug(f'{self.name} paused')
                         while True:
@@ -527,9 +524,6 @@ if aiokafka_available:
                                 _logger.debug(f'{self.name} reactivated')
                                 consumer.resume(*consumer.assignment())
                                 break
-
-                            # Send heartbeats through `getmany`
-                            await consumer.getmany()
                             await sleep(3)
 
             except Exception as e:

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -45,16 +45,6 @@ def test_dependency_init(dependency):
     assert dependency.is_down is False
 
 
-def test_dependency_save_is_down(mock_cache, dependency):
-    """Should save is_down using cache."""
-    dependency.save_is_down(mock_cache, '_prefix_', True)
-
-    loaded_dep = Dependency('emoji', iterable_to_async([]))
-    loaded_dep.load(mock_cache, '_prefix_')
-
-    assert loaded_dep.is_down is True
-
-
 def test_dependency_save_and_load(mock_cache, dependency):
     """Should save and load dependency using cache."""
     checkpoint_state = {'offset': 1}
@@ -170,7 +160,7 @@ async def test_check_pulse_initial_state(checkpoint):
 
 
 @pytest.mark.asyncio
-async def test_check_pulse_downtime_detected(checkpoint, mocker, mock_cache):
+async def test_check_pulse_downtime_detected(checkpoint, mocker):
     """Should detect downtime and pause dependent stream."""
     c = Conf()
     mock_iterable = mocker.MagicMock()
@@ -194,14 +184,9 @@ async def test_check_pulse_downtime_detected(checkpoint, mocker, mock_cache):
     assert checkpoint['dependency'].is_down is True
     assert pausable_stream.signal is Signal.PAUSE
 
-    # Downtime stored in cache
-    assert mock_cache['__test_dependency_checkpoint_is_down'] is True
-
 
 @pytest.mark.asyncio
-async def test_check_heartbeat_downtime_recovered(
-    checkpoint, mocker, mock_cache
-):
+async def test_check_heartbeat_downtime_recovered(checkpoint, mocker):
     """Should detect recovery and resume dependent stream."""
     c = Conf()
     mock_iterable = mocker.MagicMock()
@@ -243,9 +228,6 @@ async def test_check_heartbeat_downtime_recovered(
     # Recovery observed, dependent resumed
     assert checkpoint['dependency'].is_down is False
     assert pausable_stream.signal is Signal.RESUME
-
-    # Downtime stored in cache
-    assert mock_cache['__test_dependency_checkpoint_is_down'] is False
 
 
 @pytest.mark.parametrize('is_async', [True, False])


### PR DESCRIPTION
- Remove `await consumer.getmany()` call, preventing issues during Kafka disconnects
- Documentation: Increase table size of checkpoint cache in examples
- Use constants in Checkpoint